### PR TITLE
Fix empty pinned tabs styling

### DIFF
--- a/chrome/skin/tabutils.css
+++ b/chrome/skin/tabutils.css
@@ -129,9 +129,9 @@ menuseparator:last-child {
   position: relative;
 }
 
-#PinnedTabsBar:empty > *,
-#PinnedTabsBarItems:empty {
-  display: none;
+#PinnedTabsBar:empty {
+  -moz-padding-end: 0;
+  -moz-padding-start: 0;
 }
 
 .tabbrowser-tabs[multirow]:not([showPhantom="true"]) #PinnedTabsBar,


### PR DESCRIPTION
This commit properly fixes 4da116f, and issue #12, and pinned tabs being moved off screen.
I did not test it in multi-line tab bar mode, so let me know if there are any issues.
